### PR TITLE
fix: Suspense error for HotelList page

### DIFF
--- a/src/app/hotelList/page.tsx
+++ b/src/app/hotelList/page.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Suspense } from "react";
 import NavBar from "../components/NavBar";
 import HotelList from "../components/HotelList";
 import Footer from "../components/Footer";
@@ -7,7 +7,9 @@ const page = () => {
   return (
     <>
       <NavBar />
-      <HotelList />
+      <Suspense fallback={<div>Loading...</div>}>
+        <HotelList />
+      </Suspense>
       <Footer />
     </>
   );


### PR DESCRIPTION
修正在 `HotelList` 頁面上缺少 `Suspense` 邊界的問題，根據 Next.js 的要求，`useSearchParams` 必須包裹在 `Suspense` 組件中，否則會導致預渲染錯誤。此變更新增了一個 `Suspense` 邊界，並設定了 `fallback` 屬性，以便在加載內容時顯示「Loading...」訊息。

---

Error Message

```
useSearchParams() should be wrapped in a suspense boundary at page "/hotelList". Read more: https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
```